### PR TITLE
bug fix; comments element should only contain text

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -21,10 +21,8 @@
     <ver>5.0</ver>
   </compatibility>
   <comments>
-    <ul>
-      <li>Original extension (uk.co.vedaconsulting.googlegroup) development by Veda NFP Consulting Ltd (https://vedaconsulting.co.uk/) supporting CiviCRM versions upto v4.6.</li>
-      <li>Rewrite for CiviCRM v5.x funded by Greenleaf Advancement (https://greenleafadvancement.com) and Joshua Gowans (https://civicrm.org), developed by Deepak Srivastava (https://mountev.co.uk).</li>
-    </ul>
+    Original extension (uk.co.vedaconsulting.googlegroup) development by Veda NFP Consulting Ltd (https://vedaconsulting.co.uk/) supporting CiviCRM versions upto v4.6.
+    Rewrite for CiviCRM v5.x funded by Greenleaf Advancement (https://greenleafadvancement.com) and Joshua Gowans (https://civicrm.org), developed by Deepak Srivastava (https://mountev.co.uk).
   </comments>
   <civix>
     <namespace>CRM/Googlegroups</namespace>


### PR DESCRIPTION
Discovered this bug when migrating a Drupal 7.92 (PHP7.4) website that uses this extension to Drupal 9.5 (PHP8.1.2).

Extension comments are parsed through Smarty's [escape modifier](https://www.smarty.net/docsv2/en/language.modifier.escape) in the [ExtensionDetails.tpl](https://github.com/civicrm/civicrm-core/blob/969fe387ab82761c2557406e010d2e7a0819ae33/templates/CRM/Admin/Page/ExtensionDetails.tpl#L22) template. The escape modifier expects a string, but by nesting child elements inside the `<comments>` element, this results in an array being passed to the Smarty template.

On PHP7 this only causes a warning, but on PHP8 an error exception is thrown, making the CiviCRM Extensions page (/civicrm/admin/extensions) inaccessible.

**Drupal 7.92 (PHP7.4)**

<img width="1529" alt="Screenshot 2023-03-07 at 2 27 17 PM" src="https://user-images.githubusercontent.com/2798202/223580100-87e8d280-0aaa-4cf6-b984-eee566817d1c.png">
<img width="834" alt="Screenshot 2023-03-07 at 2 25 56 PM" src="https://user-images.githubusercontent.com/2798202/223580195-5f78a454-5608-447a-ab62-e79ea1495b36.png">

---

**Drupal 9.5 (PHP8.1.2)**
As of PHP 8.0, [Internal function warnings now throw TypeError and ValueError exceptions](https://php.watch/versions/8.0/internal-function-exceptions)

<img width="2485" alt="Screenshot 2023-03-07 at 2 08 31 PM" src="https://user-images.githubusercontent.com/2798202/223580951-948612c6-1b4c-4689-87b8-3a2769e74369.png">

